### PR TITLE
Add initial glossary entries

### DIFF
--- a/_pages/docs/glossary/cookie.md
+++ b/_pages/docs/glossary/cookie.md
@@ -1,0 +1,12 @@
+---
+title: cookie
+excerpt: A bit of data stored in your browser for a site to remember you by
+synonyms:
+  - tracker
+  - session cookie
+---
+A cookie in the web development refers to a bit of data that a website or web service is allowed to save in your browser to remember who you are while you browse.
+
+The term "tracker" usually refers to marketing analytics cookies—like those from Google and other ad companies—that identify your web identity and sell your trail of cookies across the web, because they are worth more as a whole than they are on their own. This is bad and we at KittyCAD don't love it.
+
+We use cookies to validate sessions with the KittyCAD API. When you access certain services from our API, we send back a session cookie, and then ask for it back periodically to ensure it's still really you asking for our services. You as a developer have to keep our cookie around to send back to us and revalidate your session.

--- a/_pages/docs/glossary/drawing.md
+++ b/_pages/docs/glossary/drawing.md
@@ -1,0 +1,9 @@
+---
+title: drawing
+excerpt: Engineering drawings or schematics
+synonyms:
+  - drawing
+  - schematic
+  - schematics
+---
+In the mechanical design world, "drawings" usually refer specifically to finished [engineering drawings](https://www.makeuk.org/insights/blogs/how-to-read-engineering-drawings-a-simple-guide#:~:text=Engineering%20drawings%20(aka%20blueprints%2C%20prints,that%20communicates%20ideas%20and%20information) that are used for manufacturing.

--- a/_pages/docs/glossary/modeling.md
+++ b/_pages/docs/glossary/modeling.md
@@ -1,0 +1,12 @@
+---
+title: modeling
+excerpt: Editing within 3 dimensions
+synonyms:
+  - design
+  - designs
+  - designing
+  - editing
+  - model
+  - models
+---
+Modeling in the mechanical design world refers to sculpting in 3D space. It is usually built up from a series of 2D sketches.

--- a/_pages/docs/glossary/scene-editing.md
+++ b/_pages/docs/glossary/scene-editing.md
@@ -1,0 +1,10 @@
+---
+title: scene editing
+excerpt: Editing scene settings lighting for rendering and exported image generation
+synonyms:
+  - scene
+  - rendering
+  - render
+  - scene setup
+---
+Scene editing within the mechanical design world refers to editing the rendering settings such as the position of the camera, the fidelity of the render passes, the lighting, the background, and in some cases the material properties of the scene.

--- a/_pages/docs/glossary/sketching.md
+++ b/_pages/docs/glossary/sketching.md
@@ -1,0 +1,8 @@
+---
+title: sketching
+excerpt: 2D editing
+synonyms:
+  - sketch
+  - sketches
+---
+Sketching in the mechanical design world refers to drawing on a 2D plane. The resulting shape is usually then extruded into 3D in order to create parts.

--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -53,10 +53,38 @@ const LegalPage = defineDocumentType(() => ({
     }
 }))
 
+const Glossary = defineDocumentType(() => ({
+    name: 'Glossary',
+    filePathPattern: `docs/glossary/*.md*`,
+    contentType: 'mdx',
+    fields: {
+        title: {
+            type: 'string',
+            description: 'Primary term of the glossary entry.',
+            required: true,
+        },
+        excerpt: {
+            type: 'string',
+            description: 'The excerpt of the glossary definition, for SEO and preview text use.',
+            required: true,
+        },
+        synonyms: {
+            type: 'list',
+            of: {
+                type: 'string',
+            },
+            description: 'Synonyms of the primary term.',
+            required: false,
+        },
+    },
+}))
+
+
 export default makeSource({
     contentDirPath: '_pages',
     documentTypes: [
         LegalPage,
         Tutorial,
+        Glossary,
     ],
 })


### PR DESCRIPTION
Towards KittyCAD/website/issues/492, adds a rough content model for glossary items and a few initial entries.

I think in the end I would love to scan through our content and wrap any instances of glossary terms or their synonyms with a link to the glossary term, as well as a hover/focus state that shows the excerpt definition.