### PR TITLE
Submodule followup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .contentlayer
 .DS_Store
+
+# Obsidian Markdown editor config files
+.obsidian

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Contains source markdown files for the handwritten parts of our docs.
 Did you find a typo? Please make a pull request!
 
 Note that the [API reference](https://kittycad.io/docs/api) and the [CLI docs](https://kittycad.io/docs/cli/manual) are generated hence why they're not included.
+
+## Live content edit preview
+
+If you have access to our website repository and you'd like to live preview your content in the website as your write/edit it, head over to that repo's README to get instructions on how to set it up.


### PR DESCRIPTION
- Updates the `.gitignore` to exclude Obsidian config
- Updates README to let people know about how to set up live preview