### PR TITLE
Add API and related terms

### DIFF
--- a/content/glossary/application-programming-interface-api.mdx
+++ b/content/glossary/application-programming-interface-api.mdx
@@ -1,0 +1,20 @@
+---
+title: API
+excerpt: An interface from one program to another.
+synonyms:
+    - API
+    - application programming interface
+    - APIs
+    - application programming interfaces
+domains:
+    - software-engineering
+---
+
+An API, or application programming interface, is a space where one software (usually called a [client](/docs/glossary/client)) can ask for things from another piece of software (a [host](/docs/glossary/host)), or ask the host to do work on their behalf. Most pieces of software operate this way, especially when connecting over the internet.
+
+You can think of an API like a menu of available options for a client[^1]. The host software curates a menu of things they're willing to provide for clients, or work they're willing to do for them, and then publishes that menu for possible clients to read. The items on this published menu are called [endpoints](/docs/glossary/endpoint). Our API follows the [OpenAPI standard](https://www.openapis.org/) so that as many pieces of software as possible can interface with its endpoints.
+
+One of the revolutionary things[^2] about KittyCAD is that we are making all of the operations and data necessary to do hardware design—from [sketching](/docs/glossary/sketching) to [modeling](/docs/glossary/modeling)—available as API endpoints. If you want to build software with just a little bit of CAD functionality in it, you can call just the endpoints you need; or if you want to build a completely new kind of CAD software by combining operations in a novel way, you can.
+
+[^1]: The restaurant metaphors don't stop there. The computers where the host software lets clients make requests are called "servers".
+[^2]: One of the other things is that these services are ridiculously fast and getting faster 🔥

--- a/content/glossary/client.mdx
+++ b/content/glossary/client.mdx
@@ -1,0 +1,10 @@
+---
+title: client
+excerpt: A computer or piece of software making requests
+domains:
+    - software-engineering
+---
+
+When discussing [APIs](/docs/glossary/application-programming-interface-api), a "client" is a machine or application making a request of a [host](/docs/glossary/host) software. Usually a client is requesting the host to return some data, such as all of the posts in your social media feed, or to perform some work on their behalf, such as [converting a 3D model to a different file type](/docs/api/convert-cad-file).
+
+Within KittyCAD, your software (and a lot of others!) is the client, and we are the host. That's why we've gotten a team of excellent software infrastructure engineers together to make our API fast even as more and more clients use it.

--- a/content/glossary/cookie.mdx
+++ b/content/glossary/cookie.mdx
@@ -3,7 +3,9 @@ title: cookie
 excerpt: A bit of data stored in your browser for a site to remember you by
 synonyms:
     - tracker
+    - trackers
     - session cookie
+    - session cookies
 domains:
     - software-engineering
 ---

--- a/content/glossary/drawing.mdx
+++ b/content/glossary/drawing.mdx
@@ -3,6 +3,7 @@ title: drawing
 excerpt: Engineering drawings or schematics
 synonyms:
     - drawing
+    - drawings
     - schematic
     - schematics
 domains:

--- a/content/glossary/endpoint.mdx
+++ b/content/glossary/endpoint.mdx
@@ -1,0 +1,17 @@
+---
+title: endpoint
+synonyms:
+    - endpoints
+    - method
+    - methods
+    - service
+    - services
+excerpt: A single callable service within an API.
+domains:
+    - software-engineering
+---
+When discussing [APIs](/glossary/application-programming-interface-api), an "endpoint" is a single service that is offered by a [host](/glossary/host) software that can be requested by a [client](/glossary/client). An endpoint on an API hosted on the internet is usually represented by a URL, such as `https://api.kittycad.io/user`.
+
+Some endpoints may ask the host fetch and return some data, like [getting your user](https://kittycad.io/docs/api/get-your-user), or ask them to perform some work for the client and return the result, like [converting a CAD file](https://kittycad.io/docs/api/convert-cad-file).
+
+KittyCAD has endpoints for hardware design actions, managing your user, and more.

--- a/content/glossary/endpoint.mdx
+++ b/content/glossary/endpoint.mdx
@@ -12,6 +12,6 @@ domains:
 ---
 When discussing [APIs](/glossary/application-programming-interface-api), an "endpoint" is a single service that is offered by a [host](/glossary/host) software that can be requested by a [client](/glossary/client). An endpoint on an API hosted on the internet is usually represented by a URL, such as `https://api.kittycad.io/user`.
 
-Some endpoints may ask the host fetch and return some data, like [getting your user](https://kittycad.io/docs/api/get-your-user), or ask them to perform some work for the client and return the result, like [converting a CAD file](https://kittycad.io/docs/api/convert-cad-file).
+Some endpoints may ask the host to fetch and return some data, like [getting your user](https://kittycad.io/docs/api/get-your-user), or ask them to perform some work for the client and return the result, like [converting a CAD file](https://kittycad.io/docs/api/convert-cad-file).
 
 KittyCAD has endpoints for hardware design actions, managing your user, and more.

--- a/content/glossary/host.mdx
+++ b/content/glossary/host.mdx
@@ -1,0 +1,10 @@
+---
+title: host
+excerpt: A computer or piece of software allowing others to make requests of it.
+domains:
+    - software-engineering
+---
+
+When discussing [APIs](/docs/glossary/application-programming-interface-api), a "host" is a machine or application that has some functionality added to it allowing it to take requests from one or more [clients](/docs/glossary/client). A host may fetch some data or resources for the client, do some work on its behalf, or usually some combination of the two.
+
+With KittyCAD, we are the host and your software (and a lot of others!) is the client. That's why we've assembled a team of software infrastructure experts to make our API services fast and ready to scale.

--- a/content/glossary/host.mdx
+++ b/content/glossary/host.mdx
@@ -1,6 +1,10 @@
 ---
 title: host
 excerpt: A computer or piece of software allowing others to make requests of it.
+synonyms:
+    - hosts
+    - server
+    - servers
 domains:
     - software-engineering
 ---

--- a/content/glossary/memory.mdx
+++ b/content/glossary/memory.mdx
@@ -3,6 +3,7 @@ title: memory
 excerpt: Holds programs or files that your computer is actively using.
 synonyms:
     - RAM
+    - random-access memory
 domains:
     - software-engineering
 ---

--- a/content/glossary/storage.mdx
+++ b/content/glossary/storage.mdx
@@ -2,9 +2,15 @@
 title: storage
 excerpt: Stores programs and files, forever (or until you delete them).
 synonyms:
-    - Disk
-    - Hard drive (HDD)
-    - Solid state drive (SDD)
+    - disk
+    - hard drive
+    - hard drives
+    - HD
+    - hard drive (HD)
+    - solid-state drive
+    - solid-state drives
+    - SSD
+    - solid-state drive (SSD)
 domains:
     - software-engineering
 ---


### PR DESCRIPTION
Reviewers are optional if you're interested in looking these over, no rush!

Adds entries for:
- API
- host
- client
- endpoint

and adds more synonyms for existing posts. I think we should make a rule to include **plurals** of any terms in the synonyms, because I want us to be able to wrap the entire term when we add the website term scanning functionality, even with compound plurals like "application programming interfaces".