### PR TITLE
Replace broken link to missing command

### DIFF
--- a/content/pages/docs/cli/manual/index.md
+++ b/content/pages/docs/cli/manual/index.md
@@ -13,7 +13,7 @@ You can find installation instructions on [the latest release](https://github.co
 
 ## Configuration
 
-Run [`kittycad auth login`](/docs/cli/manual/kittycad_auth_login) to authenticate with your KittyCAD account. Alternatively, `kittycad` will respect the `KITTYCAD_TOKEN` [environment variable](/docs/cli/manual/kittycad_help_environment).
+Run [`kittycad auth login`](/docs/cli/manual/kittycad_auth_login) to authenticate with your KittyCAD account. Alternatively, `kittycad` will respect the `KITTYCAD_TOKEN` [environment variable](/docs/cli/manual/kittycad#about).
 
 Declare your aliases for often-used commands with [`kittycad alias set`](/docs/cli/manual/kittycad_alias_set).
 


### PR DESCRIPTION
@jessfraz it looks like the `kittycad help environment` command is gone, making this link break. I've just replaced it with a section that lists the usable environment variables, but I wanted to flag it for you in case something's up with the CLI.