### PR TITLE
Update api urls

### DIFF
--- a/content/changelog/2022-q3.mdx
+++ b/content/changelog/2022-q3.mdx
@@ -20,14 +20,14 @@ date: '2022-10-17T14:00:00.000Z'
 -   [Unit conversions galore](https://kittycad.io/docs/api/unit). We got conversions for ya temperatures, we got conversions for ya lengths, we got conversions for ya forces and even conversions for ya pressures. Conversions, conversions, everywhere! 🔢
 -   [Physics Constants](https://kittycad.io/docs/api/constant). Need a handy-dandy value for your calculation? Now you have it 🧮 ~
     -   (Note this is a `GET` endpoint - 😉 you know what that means for [billing](https://kittycad.io/docs/billing#important-info))
--   [Surface Area](https://kittycad.io/docs/api/get-cad-file-surface-area) endpoint calculation, aka how much wrapping paper do you need to wrap that present box 🎁
--   [Center of Mass](https://kittycad.io/dos/api/get-cad-file-center-of-mass) endpoint calculation, for all you jenga balancing experts out there 🧐
--   [New 2D Vector File Conversions](https://kittycad.io/docs/api/convert-2d-vector-file) for your svg and dxf nightmares 🎃
-    -   this is done as part of a split into 3 endpoint possibilities; the original generic [file_convert](https://kittycad.io/docs/api/convert-cad-file) or if you'd like to be specific [file_convert for 3d files](https://kittycad.io/docs/api/convert-2d-vector-file), and [file_convert for 2d vector files](https://kittycad.io/docs/api/convert-2d-vector-file)
+-   [Surface Area](https://kittycad.io/docs/api/file/get-cad-file-surface-area) endpoint calculation, aka how much wrapping paper do you need to wrap that present box 🎁
+-   [Center of Mass](https://kittycad.io/dos/api/file/get-cad-file-center-of-mass) endpoint calculation, for all you jenga balancing experts out there 🧐
+-   ~New 2D Vector File Conversions for your svg and dxf nightmares 🎃~
+    -   this is done as part of a split into 3 endpoint possibilities; the original generic [file_convert](https://kittycad.io/docs/api/file/convert-cad-file-with-defaults) or if you'd like to be specific ~[file_convert for 3d files](https://kittycad.io/docs/api/convert-2d-vector-file), and [file_convert for 2d vector files](https://kittycad.io/docs/api/convert-2d-vector-file)~ (deprecated since publication)
 
 ### What's Been Updated
 
--   [More Metric Unit Conversions](https://kittycad.io/docs/api/unit). Added more metric conversions ([general](https://kittycad.io/docs/api/convert-metric-units), [squared](https://kittycad.io/docs/api/convert-metric-squared-units), [cubed](https://kittycad.io/docs/api/convert-metric-cubed-units)) to help on top of any unit conversions you're working through 🔢
+-   ~[More Metric Unit Conversions](https://kittycad.io/docs/api/unit). Added more metric conversions ([general](https://kittycad.io/docs/api/convert-metric-units), [squared](https://kittycad.io/docs/api/convert-metric-squared-units), [cubed](https://kittycad.io/docs/api/convert-metric-cubed-units)) to help on top of any unit conversions you're working through 🔢~ (deprecated since publication)
 
 ### New Blog Posts
 

--- a/content/changelog/2022-q4.mdx
+++ b/content/changelog/2022-q4.mdx
@@ -19,9 +19,9 @@ date: '2022-12-23T14:00:00.000Z'
 
 > _More things coming down the pipe!_
 
--   [Units Units Units](https://kittycad.io/docs/api/unit). New unit conversion added for [radioactivity](https://kittycad.io/docs/api/convert-radioactivity-units) along with many more possible parameter formats for pre-existing units. Measure, weigh, calculate to your heart's content! 🔢
--   [More 2D Vector File Export Formats](https://kittycad.io/docs/api/convert-2d-vector-file) [png, pdf, ps] for all your design interaction needs 🎨
--   Dealing with those 3D scanners? Not to worry - we got you covered with our new support for [Import/Export with PLY](https://kittycad.io/docs/api/convert-3d-file)
+-   [Units Units Units](https://kittycad.io/docs/api/unit). New unit conversion added for ~[radioactivity](https://kittycad.io/docs/api/convert-radioactivity-units)~ (deprecated since publication) along with many more possible parameter formats for pre-existing units. Measure, weigh, calculate to your heart's content! 🔢
+-   ~[More 2D Vector File Export Formats](https://kittycad.io/docs/api/convert-2d-vector-file) [png, pdf, ps] for all your design interaction needs 🎨~ (deprecated since publication)
+-   Dealing with those 3D scanners? Not to worry - we got you covered with our new support for [Import/Export with PLY](https://kittycad.io/docs/api/file/convert-cad-file-with-defaults)
 
 ### Some Sneak Peeks of What's in Work
 

--- a/content/glossary/client.mdx
+++ b/content/glossary/client.mdx
@@ -5,6 +5,6 @@ domains:
     - software-engineering
 ---
 
-When discussing [APIs](/docs/glossary/application-programming-interface-api), a "client" is a machine or application making a request of a [host](/docs/glossary/host) software. Usually a client is requesting the host to return some data, such as all of the posts in your social media feed, or to perform some work on their behalf, such as [converting a 3D model to a different file type](/docs/api/convert-cad-file).
+When discussing [APIs](/docs/glossary/application-programming-interface-api), a "client" is a machine or application making a request of a [host](/docs/glossary/host) software. Usually a client is requesting the host to return some data, such as all of the posts in your social media feed, or to perform some work on their behalf, such as [converting a 3D model to a different file type](/docs/api/file/convert-cad-file-with-defaults).
 
 Within KittyCAD, your software (and a lot of others!) is the client, and we are the host. That's why we've gotten a team of excellent software infrastructure engineers together to make our API fast even as more and more clients use it.

--- a/content/glossary/endpoint.mdx
+++ b/content/glossary/endpoint.mdx
@@ -12,6 +12,6 @@ domains:
 ---
 When discussing [APIs](/glossary/application-programming-interface-api), an "endpoint" is a single service that is offered by a [host](/glossary/host) software that can be requested by a [client](/glossary/client). An endpoint on an API hosted on the internet is usually represented by a URL, such as `https://api.kittycad.io/user`.
 
-Some endpoints may ask the host to fetch and return some data, like [getting your user](https://kittycad.io/docs/api/get-your-user), or ask them to perform some work for the client and return the result, like [converting a CAD file](https://kittycad.io/docs/api/convert-cad-file).
+Some endpoints may ask the host to fetch and return some data, like [getting your user](https://kittycad.io/docs/api/user/get-your-user), or ask them to perform some work for the client and return the result, like [converting a CAD file](https://kittycad.io/docs/api/file/convert-cad-file-with-defaults).
 
 KittyCAD has endpoints for hardware design actions, managing your user, and more.

--- a/content/posts/api-first-approach.mdx
+++ b/content/posts/api-first-approach.mdx
@@ -18,7 +18,7 @@ Our products aren't 3D modeling software suites. We make tools that allow any so
 
 To support any application big or small, KittyCAD's functionality is broken up into many individual services, called endpoints. This is our API, and it allows developers to build in only the functionality they need, and leave out whatever they don’t.
 
-You may build a file converter app just using our [convert](https://kittycad.io/docs/api/convert-cad-file) API endpoint, while someone building a full-featured CAD suite may use our [design endpoints](https://kittycad.io/docs/api/open-a-websocket-which-accepts-modeling-commands) to let their users generate 3D models through a traditional user interface. Both these developers got only the features they needed, and both haven't had to think about the complexities of CAD file formats, [rendering engines](https://kittycad.io/geometry-engine), or most of the other thorny problems of building hardware design tools. That's what KittyCAD is for.
+You may build a file converter app just using our [convert](https://kittycad.io/docs/api/file/convert-cad-file-with-defaults) API endpoint, while someone building a full-featured CAD suite may use our [design endpoints](https://kittycad.io/docs/api/modeling/open-a-websocket-which-accepts-modeling-commands) to let their users generate 3D models through a traditional user interface. Both these developers got only the features they needed, and both haven't had to think about the complexities of CAD file formats, [rendering engines](https://kittycad.io/geometry-engine), or most of the other thorny problems of building hardware design tools. That's what KittyCAD is for.
 
 
 ## The problem with selling a user interface

--- a/content/tutorials/file-metadata.mdx
+++ b/content/tutorials/file-metadata.mdx
@@ -20,7 +20,4 @@ Below is our API-client code:
 
 {/* __PRE-FETCH__: tutorials/get_mass_volume */}
 
-<InlineLitterbox
-    path="tutorials/get_mass_volume"
-    initialExpand
-/>
+<SamplePreview path="tutorials/get_mass_volume" />

--- a/content/tutorials/obj-stl-conversion.mdx
+++ b/content/tutorials/obj-stl-conversion.mdx
@@ -21,7 +21,4 @@ Below is our API-client code:
 
 {/* __PRE-FETCH__: tutorials/conversion_obj_stl */}
 
-<InlineLitterbox
-    path="tutorials/conversion_obj_stl"
-    initialExpand
-/>
+<SamplePreview path="tutorials/conversion_obj_stl" />


### PR DESCRIPTION
I've just updated the website to use a new docs layout, including a new URL pattern for API pages: from `/docs/api/[endpoint]` to `docs/api/[tag]/[endpoint]`. This PR updates the URLs to API page within the docs that would break.