### PR TITLE
Update glossary casing

### DIFF
--- a/content/glossary/client.mdx
+++ b/content/glossary/client.mdx
@@ -1,5 +1,5 @@
 ---
-title: client
+title: Client
 excerpt: A computer or piece of software making requests
 domains:
     - software-engineering

--- a/content/glossary/cookie.mdx
+++ b/content/glossary/cookie.mdx
@@ -1,5 +1,5 @@
 ---
-title: cookie
+title: Cookie
 excerpt: A bit of data stored in your browser for a site to remember you by
 synonyms:
     - tracker

--- a/content/glossary/drawing.mdx
+++ b/content/glossary/drawing.mdx
@@ -1,5 +1,5 @@
 ---
-title: drawing
+title: Drawing
 excerpt: 2D representation of a 3D object to be manufactured
 synonyms:
     - drawing

--- a/content/glossary/endpoint.mdx
+++ b/content/glossary/endpoint.mdx
@@ -1,12 +1,12 @@
 ---
-title: endpoint
+title: Endpoint
+excerpt: A single callable service within an API.
 synonyms:
     - endpoints
     - method
     - methods
     - service
     - services
-excerpt: A single callable service within an API.
 domains:
     - software-engineering
 ---

--- a/content/glossary/host.mdx
+++ b/content/glossary/host.mdx
@@ -1,5 +1,5 @@
 ---
-title: host
+title: Host
 excerpt: A computer or piece of software allowing others to make requests of it.
 synonyms:
     - hosts

--- a/content/glossary/index.mdx
+++ b/content/glossary/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: glossary
+title: Glossary
 excerpt: Home to Zoo's lexicon
 domains:
     - software-engineering

--- a/content/glossary/memory.mdx
+++ b/content/glossary/memory.mdx
@@ -1,5 +1,5 @@
 ---
-title: memory
+title: Memory
 excerpt: Holds programs or files that your computer is actively using.
 synonyms:
     - RAM

--- a/content/glossary/modeling.mdx
+++ b/content/glossary/modeling.mdx
@@ -1,5 +1,5 @@
 ---
-title: modeling
+title: Modeling
 excerpt: Creating a digital representation of a physical object.
 synonyms:
     - designing

--- a/content/glossary/part.mdx
+++ b/content/glossary/part.mdx
@@ -1,6 +1,6 @@
 ---
 title: Part
-excerpt: an individual component of a design.
+excerpt: An individual component of a design.
 synonyms:
     - component
     - piece part

--- a/content/glossary/scale.mdx
+++ b/content/glossary/scale.mdx
@@ -1,6 +1,6 @@
 ---
 title: Scale
-excerpt: the proportional relationship between the dimensions of the drawing and the real-world size of the objects or components being represented.
+excerpt: The proportional relationship between the dimensions of the drawing and the real-world size of the objects or components being represented.
 synonyms:
     - ratio
 domains:

--- a/content/glossary/scene-editing.mdx
+++ b/content/glossary/scene-editing.mdx
@@ -1,5 +1,5 @@
 ---
-title: scene editing
+title: Scene Editing
 excerpt: Editing scene settings lighting for rendering and exported image generation
 synonyms:
     - scene

--- a/content/glossary/sketching.mdx
+++ b/content/glossary/sketching.mdx
@@ -1,5 +1,5 @@
 ---
-title: sketching
+title: Sketching
 excerpt: 2D editing
 synonyms:
     - sketch

--- a/content/glossary/storage.mdx
+++ b/content/glossary/storage.mdx
@@ -1,5 +1,5 @@
 ---
-title: storage
+title: Storage
 excerpt: Stores programs and files, forever (or until you delete them).
 synonyms:
     - disk

--- a/content/glossary/view.mdx
+++ b/content/glossary/view.mdx
@@ -1,6 +1,6 @@
 ---
 title: View
-excerpt: a visual perspective of the model 
+excerpt: A visual perspective of the model 
 synonyms:
     - perspective
 domains:


### PR DESCRIPTION
I was browsing the glossary and noticed some of the casing was inconsistent, so I updated all of the titles to use Title Case and excerpts to use Sentence case, and now they all match. I also proofread all the definitions, everything looks good to me.