### PR TITLE
Update Text-to-CAD tutorial

### DIFF
--- a/content/tutorials/text-to-cad.mdx
+++ b/content/tutorials/text-to-cad.mdx
@@ -47,11 +47,15 @@ Import the libraries necessary to create and retrieve models with Text-to-CAD:
 ```py
 import time
 
-from kittycad.api.ai import create_text_to_cad, get_text_to_cad_model_for_user
+from kittycad.api.ml import create_text_to_cad, get_text_to_cad_model_for_user
 from kittycad.client import ClientFromEnv
-from kittycad.models.api_call_status import ApiCallStatus
-from kittycad.models.file_export_format import FileExportFormat
-from kittycad.models.text_to_cad_create_body import TextToCadCreateBody
+from kittycad.models import (
+    ApiCallStatus,
+    Error,
+    FileExportFormat,
+    TextToCad,
+    TextToCadCreateBody,
+)
 ```
 
 ## Initialize the client
@@ -76,6 +80,10 @@ response = create_text_to_cad.sync(
         prompt="Design a gear with 40 teeth",
     ),
 )
+
+if isinstance(response, Error) or response is None:
+    print(f"Error: {response}")
+    exit(1)
 ```
 
 ## Checking the status
@@ -83,16 +91,24 @@ response = create_text_to_cad.sync(
 Now that we have made the API call, we need to check the status of the model. We can do this by using the `get_text_to_cad_model_for_user.sync()` function. This function takes in the client and the ID of the request that we want to check the status. keep in mind that more complex prompts will take more time to process. In this example, we check the status every 5 seconds until the original request is complete.
 
 ```py
+result: TextToCad = response
+
 # Polling to check if the task is complete
-while response.completed_at is None:
+while result.completed_at is None:
     # Wait for 5 seconds before checking again
     time.sleep(5)
 
     # Check the status of the task
     response = get_text_to_cad_model_for_user.sync(
         client=client,
-        id=response.id,
+        id=result.id,
     )
+
+    if isinstance(response, Error) or response is None:
+        print(f"Error: {response}")
+        exit(1)
+
+    result = response
 ```
 
 ## Save the final result
@@ -106,20 +122,24 @@ In our script, if Text-to-CAD returns an error, we want to print the error messa
 In this example, we will save the STEP file to our file system. The API returns a base64 encoded string, so we decode it to plain text and save it as a `.step` file.
 
 ```py
-if response.status == ApiCallStatus.FAILED:
+if result.status == ApiCallStatus.FAILED:
     # Print out the error message
-    print(f"Text-to-CAD failed: {response.error}")
+    print(f"Text-to-CAD failed: {result.error}")
 
-elif response.status == ApiCallStatus.COMPLETED:
+elif result.status == ApiCallStatus.COMPLETED:
+    if result.outputs is None:
+        print("Text-to-CAD completed but returned no files.")
+        exit(0)
+
     # Print out the names of the generated files
-    print(f"Text-to-CAD completed and returned {len(response.outputs)} files:")
-    for name in response.outputs:
+    print(f"Text-to-CAD completed and returned {len(result.outputs)} files:")
+    for name in result.outputs:
         print(f"  * {name}")
 
     # Save the STEP data as text-to-cad-output.step
-    final_result = response.outputs["source.step"]
+    final_result = result.outputs["source.step"]
     with open("text-to-cad-output.step", "w", encoding="utf-8") as output_file:
-        output_file.write(final_result.get_decoded().decode("utf-8"))
+        output_file.write(final_result.decode("utf-8"))
         print(f"Saved output to {output_file.name}")
 ```
 


### PR DESCRIPTION
Code snippets in the tutorial were out of sync with the content from https://github.com/KittyCAD/litterbox/blob/main/tutorials/text-to-cad/text-to-cad.py