### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS migrated from dependabot reviewers
-*       @Irev-Dev @adamchalmers @franknoirot @jessfraz @jgomez720
+*       @Irev-Dev @adamchalmers @franknoirot @jessfraz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS migrated from dependabot reviewers
+*       @Irev-Dev @adamchalmers @franknoirot @jessfraz @jgomez720


### PR DESCRIPTION
Dependabot is moving away from reviewers flag and CODEOWNERS should be used instead: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

This PR is people from dependabot.
