### PR TITLE
Fix broken link to `coincident()`

### DIFF
--- a/content/pages/docs/kcl-std/functions/std-solver-fixed.md
+++ b/content/pages/docs/kcl-std/functions/std-solver-fixed.md
@@ -13,6 +13,6 @@ solver::fixed
 
 `fixed()` is an alias for `coincident()`. By convention, `fixed()` is used when one of the points is a known location, not solved with constraints and not another point in the sketch.
 
-See [coincident()](/docs/kcl-std/functions/std-sketch2-coincident) for more info.
+See [coincident()](/docs/kcl-std/functions/std-solver-coincident) for more info.
 
 


### PR DESCRIPTION
This link is broken on https://zoo.dev/docs/kcl-std/functions/std-solver-fixed