### PR TITLE
Fix modes plan image alignment

### DIFF
--- a/content/pages/docs/zoo-design-studio/features/ml-ai/modes/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/ml-ai/modes/index.mdx
@@ -50,7 +50,6 @@ plan includes them.
   alt="Zookeeper mode selector for a Free user with Standard and Thoughtful unavailable and Auto selected"
   aspect="359 / 454"
   maxHeightPx={454}
-  className="max-w-sm mb-14"
 />
 
 ### Paid plans
@@ -63,7 +62,6 @@ Standard for speed, or Thoughtful for deeper CAD reasoning.
   alt="Zookeeper mode selector for a paid user with Standard, Thoughtful, and Auto available"
   aspect="308 / 436"
   maxHeightPx={436}
-  className="max-w-xs"
 />
 
 For the full assistant workflow, see [Zookeeper](/docs/zoo-design-studio/zookeeper) and


### PR DESCRIPTION
ai assisted

## Problem
The Zookeeper Modes docs page uses custom image sizing classes that shift the plan screenshots out of the normal docs content flow.

## Solution
Remove the custom alignment classes so the plan screenshots use the same framed-image layout as the rest of the docs feature pages.
