### PR TITLE
Remove outdated Zookeeper roadmap items

### DIFF
--- a/content/pages/docs/zoo-design-studio/zookeeper.mdx
+++ b/content/pages/docs/zoo-design-studio/zookeeper.mdx
@@ -135,15 +135,11 @@ The selector keeps unavailable modes visible so users can see what an upgraded p
 
 ## What's Coming Next
 
-The agent described above is only the beginning. Several upcoming capabilities will extend both its reach and its usefulness.
-
-- **More agent selection controls** will allow users to choose the underlying language model and system prompt that define the agent’s behavior.
-
-- **Sketch-to-CAD** will allow users to sketch directly over models when drawing is faster or clearer than describing an idea in words—combining visual input with conversational intent.
+The agent described above is only the beginning. An upcoming capability will extend both its reach and its usefulness.
 
 - **Fleets of agents** will make it possible to manage a team of Zookeeper agents working concurrently. Agents can be assigned to different features, components, or projects in parallel, or coordinate to complete a single task faster.
 
-Each of these features expands the bandwidth between the designer’s intent and the system that represents it.
+This feature will expand the bandwidth between the designer’s intent and the system that represents it.
 
 ## CAD as Collaboration
 


### PR DESCRIPTION
Removes the shipped agent-selection and Sketch-to-CAD items from Zookeeper's "What's Coming Next" section. The page already documents the available agent modes, and Zoodle now covers sketch-based visual guidance.

The fleets roadmap item remains.
