### PR TITLE
Label STEP import experimental on overview

### DIFF
--- a/content/pages/docs/zoo-design-studio/features/data-management/import.mdx
+++ b/content/pages/docs/zoo-design-studio/features/data-management/import.mdx
@@ -13,6 +13,7 @@ Zoo Design Studio supports the following file formats for import into projects:
 ### CAD Formats
 
 **STEP (.step, .stp)**
+- 🧪 **Experimental:** STEP import supports read-only 3D geometry. Imported geometry cannot be edited, and 2D STEP drawings are not supported.
 - Standard for the Exchange of Product model data (ISO 10303)
 - Industry-standard neutral CAD format
 - Preserves solid geometry, assemblies, and product structure


### PR DESCRIPTION
Adds an experimental notice to the STEP entry on the import overview page.

The notice clarifies that STEP import currently supports read-only 3D geometry, imported geometry cannot be edited, and 2D STEP drawings are not supported.
