### PR TITLE
Update privacy policy

### DIFF
--- a/content/pages/privacy-policy.mdx
+++ b/content/pages/privacy-policy.mdx
@@ -5,7 +5,7 @@ excerpt: 'Our Privacy Policy'
 
 # Zoo Privacy Policy
 
-**Last Updated**: August 10, 2026
+**Last Updated**: August 11, 2026
 
 This Privacy Notice applies to the processing of personal information by Zoo Corporation (“**Zoo**,” “**we**,” “**us**,” or “**our**”) including on our website available at https://zoo.dev and our other online or offline offerings which link to, or are otherwise subject to, this Privacy Notice (collectively, the “**Services**”). 
 

--- a/content/pages/privacy-policy.mdx
+++ b/content/pages/privacy-policy.mdx
@@ -5,7 +5,7 @@ excerpt: 'Our Privacy Policy'
 
 # Zoo Privacy Policy
 
-**Last Updated**: February 22, 2024
+**Last Updated**: August 10, 2026
 
 This Privacy Notice applies to the processing of personal information by Zoo Corporation (“**Zoo**,” “**we**,” “**us**,” or “**our**”) including on our website available at https://zoo.dev and our other online or offline offerings which link to, or are otherwise subject to, this Privacy Notice (collectively, the “**Services**”). 
 
@@ -16,10 +16,11 @@ This Privacy Notice applies to the processing of personal information by Zoo Cor
 3. [HOW WE USE PERSONAL INFORMATION](#3-how-we-use-personal-information)
 4. [HOW WE DISCLOSE PERSONAL INFORMATION](#4-how-we-disclose-personal-information)
 5. [YOUR PRIVACY CHOICES AND RIGHTS](#5-your-privacy-choices-and-rights)
-6. [INTERNATIONAL TRANSFERS OF PERSONAL INFORMATION](#6-international-transfers-of-personal-information)
-7. [CHILDREN’S PERSONAL INFORMATION](#7-childrens-personal-information)
-8. [THIRD-PARTY WEBSITES/APPLICATIONS](#8-third-party-websites-applications)
-9. [CONTACT US](#9-contact-us)
+6. [DATA RETENTION](#6-data-retention)
+7. [INTERNATIONAL TRANSFERS OF PERSONAL INFORMATION](#7-international-transfers-of-personal-information)
+8. [CHILDREN’S PERSONAL INFORMATION](#8-childrens-personal-information)
+9. [THIRD-PARTY WEBSITES/APPLICATIONS](#9-third-party-websites-applications)
+10. [CONTACT US](#10-contact-us)
 
 ## 1. UPDATES TO THIS PRIVACY NOTICE
 We may update this Privacy Notice from time to time in our sole discretion. If we do, we’ll let you know by posting the updated Privacy Notice on our website, and/or we may also send other communications. 
@@ -46,6 +47,19 @@ We may collect personal information automatically when you use the Services.
 - **Cookie Notice (and Other Technologies)**. We, as well as third parties, may use cookies, pixel tags, and other technologies (“Technologies”) to automatically collect personal information through your use of the Services. *See “[Your Privacy Choices and Rights](#your-privacy-choices-and-rights)” below to understand your choices regarding these Technologies.*
 	- **Cookies**. [Cookies](/docs/glossary/cookie) are small text files stored in device browsers.
 	- **Pixel Tags/Web Beacons**. A pixel tag (also known as a web beacon) is a piece of code embedded in the Services that collects personal information about use of or engagement with the Services. The use of a pixel tag allows us to record, for example, that a user has visited, a particular web page or clicked on a particular advertisement. We may also include web beacons in e-mails to understand whether messages have been opened, acted on, or forwarded.
+
+### Optional Analytics and Advertising Technologies
+
+When you visit our website, we ask whether you want to allow the optional categories described below. These technologies remain off unless you enable the applicable category. You can enable or disable each category independently and change your selection at any time through **Privacy settings** in the website footer.
+
+| Category | Providers and technologies | Purpose |
+| --- | --- | --- |
+| Analytics | Vercel Analytics, Vercel Speed Insights, and Microsoft Clarity | Measure website usage and performance, understand how visitors interact with pages, diagnose usability issues, and improve the Services. |
+| Advertising | Google Ads and Google Tag Manager, LinkedIn, X, and Reddit | Measure campaigns and conversions, understand which advertisements lead to visits or signups, and support advertising and attribution. |
+
+Depending on the provider and your settings, these technologies may process device and browser information, IP address and approximate location derived from it, pages viewed, referring URLs, interactions with the Services, cookie or similar identifiers, and campaign or conversion information. Google Tag Manager is a tag-management service that may be used to deploy other analytics or advertising technologies identified in this notice; it is not used as a separate purpose for processing personal information.
+
+We also store your analytics and advertising selections in your browser's local storage. This preference record contains your category choices, the version of the privacy notice against which the choice was made, and the time it was saved. It allows us to remember and apply your choices on later visits from the same browser.
 
 ### Personal Information Collected from Third Parties
 We may collect personal information about you from third parties.  For example, if you access the Services using a Third-Party Service (defined below), we may collect personal information about you from that Third-Party Service that you have made available via your privacy settings. In addition, users of the Services may upload or otherwise provide personal information about others.
@@ -83,7 +97,7 @@ We use personal information for various administrative purposes, such as:
 ### Marketing
 We may use personal information to tailor and provide you with marketing and other content. We may provide you with these materials as permitted by applicable law. 
 
-If you have any questions about our marketing practices, you may contact us at any time as set forth in “[Contact Us](#9-contact-us)” below. 
+If you have any questions about our marketing practices, you may contact us at any time as set forth in “[Contact Us](#10-contact-us)” below. 
 
 ### With Your Consent or Direction 
 
@@ -95,9 +109,13 @@ We disclose personal information to third parties for a variety of business purp
 ### Disclosures to Provide the Services
 We may disclose any of the personal information we collect to the categories of third parties described below.
 
-- **Service Providers**. We may disclose personal information to third-party service providers that assist us with the provision of the Services. This may include, but is not limited to, service providers that provide us with hosting, customer service, analytics, marketing services, IT support, and related services. In addition, personal information and chat communications may be disclosed to service providers that help provide our chat features. Some of the service providers we may use include: 
-	- **Google Tag Manager**.  For more information about how Google Tag Manager uses your personal information, please review the [Google Tag Manager Terms of Service](https://marketingplatform.google.com/about/analytics/tag-manager/use-policy/) and [Privacy Policy](https://policies.google.com/privacy?hl=en).
-	- **X (formerly known as Twitter) Analytics**.  For more information about how X uses your personal information, please review the [X Privacy Policy](https://twitter.com/en/privacy).
+- **Service Providers**. We may disclose personal information to third-party service providers that assist us with the provision of the Services. This may include, but is not limited to, service providers that provide us with hosting, customer service, analytics, marketing services, IT support, and related services. In addition, personal information and chat communications may be disclosed to service providers that help provide our chat features. Providers used for optional website analytics and advertising include:
+		- **Vercel Analytics and Speed Insights**. For more information, review the [Vercel Privacy Policy](https://vercel.com/legal/privacy-policy).
+		- **Microsoft Clarity**. For more information, review the [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement).
+		- **Google Ads and Google Tag Manager**. For more information, review the [Google Privacy Policy](https://policies.google.com/privacy) and [Google Tag Manager Use Policy](https://marketingplatform.google.com/about/analytics/tag-manager/use-policy/).
+		- **LinkedIn**. For more information, review the [LinkedIn Privacy Policy](https://www.linkedin.com/legal/privacy-policy).
+		- **X (formerly known as Twitter)**. For more information, review the [X Privacy Policy](https://twitter.com/en/privacy).
+		- **Reddit**. For more information, review the [Reddit Privacy Policy](https://www.reddit.com/policies/privacy-policy).
 - **Third-Party Services You Share or Interact With**. The Services may link to or allow you to interface, interact, share information with, direct us to share information with, access and/or use third-party websites, applications, services, products, and technology (each a “Third-Party Service”). Any personal information shared with a Third-Party Service will be subject to the Third- Party Service’s privacy policy. We are not responsible for the processing of personal information by Third-Party Services.
 - **Business Partners**. We may share your personal information with business partners to provide you with a product or service you have requested. We may also share your personal information with business partners with whom we jointly offer products or services.  Once your personal information is shared with our business partner, it will also be subject to our business partner’s privacy policy. We are not responsible for the processing of personal information by our business partners. 
 - **Zoo Customers (Authorized Users Only)**. In cases where you use our Services as an employee, contractor, or other authorized user of a Zoo customer, that customer may access information associated with your use of the Services including usage data and the contents of the communications and files associated with your account. Your personal information may also be subject to the Zoo customer’s privacy policy. We are not responsible for the Zoo customer’s processing of your personal information. 
@@ -114,8 +132,9 @@ If we are involved in a merger, acquisition, financing, reorganization, bankrupt
 
 **Your Privacy Choices.** The privacy choices you may have about your personal information are described below. 
 - **Email Communications**. If you receive an unwanted email from us, you can use the unsubscribe functionality found at the bottom of the email to opt out of receiving future emails. Note that you will continue to receive transaction-related emails. We may also send you certain non-promotional communications regarding us and the Services, and you will not be able to opt out of those communications (e.g., communications regarding the Services or updates to this Privacy Notice).
-- **“Do Not Track.”** Do Not Track (“DNT”) is a privacy preference that users can set in certain web browsers. Please note that we do not respond to or honor DNT signals or similar mechanisms transmitted by web browsers.
-- **Cookies**. You may stop or restrict the placement of Technologies on your device or remove them by adjusting your preferences as your browser or device permits. However, if you adjust your preferences, the Services may not work properly. 
+- **Optional Analytics and Advertising Choices**. You can use the consent notice shown on your first visit to enable or reject optional analytics and advertising technologies. You can later review, change, or withdraw those choices through **Privacy settings** in the website footer. Withdrawing a choice applies to future processing in that browser. We will attempt to remove optional first-party cookies accessible to the website, but cookies previously placed by third parties may also need to be removed through your browser or the third party's controls.
+- **“Do Not Track.”** Do Not Track (“DNT”) is a privacy preference that users can set in certain web browsers. We do not currently respond to DNT signals. DNT is distinct from legally recognized opt-out preference signals such as Global Privacy Control (“GPC”). Where required by applicable law, we treat a detected GPC signal as a request to opt out of the sale or sharing of personal information and targeted advertising, and we disable the optional advertising category for that browser.
+- **Cookies and Browser Storage**. You may also stop or restrict the placement of Technologies on your device, remove them, or clear locally stored preferences through your browser or device settings. Clearing browser data may cause the consent notice to appear again. Some browser settings may affect the functionality of the Services.
 
 Please note that cookie-based opt-outs are not effective on mobile applications. However, you may opt-out of certain tracking on some mobile applications by following the instructions for [Android](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en), [iOS](https://support.apple.com/en-us/HT202074), and [others](https://www.networkadvertising.org/mobile-choice/).
 
@@ -131,22 +150,28 @@ Please note you must separately opt out in each browser and on each device.
 - **Request to Opt-Out of Certain Processing Activities** including, as applicable, if we process your personal information for “targeted advertising” (as “targeted advertising” is defined by applicable privacy laws),  if we “sell” your personal information (as “sell” is defined by applicable privacy laws), or if we engage in “profiling” in furtherance of certain “decisions that produce legal or similarly significant effects” concerning you (as such terms are defined by applicable privacy laws); and
 - **Withdraw Your Consent to our Processing of Your Personal Information**. Please note that your withdrawal will only take effect for future processing, and will not affect the lawfulness of processing before the withdrawal.
 
-If you would like to exercise any of these rights, please contact us as set forth in “[Contact Us](#9-contact-us)” below. We will process such requests in accordance with applicable laws.
+If you would like to exercise any of these rights, please contact us as set forth in “[Contact Us](#10-contact-us)” below. We will process such requests in accordance with applicable laws.
 
 To protect your privacy, we will take steps to verify your identity before fulfilling requests submitted under applicable privacy laws. These steps may involve asking you to provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative. Examples of our verification process may include asking you to confirm the email address we have associated with you.
 
-## 6. INTERNATIONAL TRANSFERS OF PERSONAL INFORMATION
-All personal information processed by us may be transferred, processed, and stored anywhere in the world, including, but not limited to, the United States or other countries, which may have data protection laws that are different from the laws where you live.  
+## 6. DATA RETENTION
 
-## 7. CHILDREN’S PERSONAL INFORMATION
+We retain personal information for as long as reasonably necessary to provide the Services, fulfill the purposes described in this Privacy Notice, comply with legal obligations, resolve disputes, enforce agreements, and protect the Services and our users. The applicable retention period depends on the type of information, the purpose for which it was collected, applicable legal requirements, and our operational needs. Optional analytics and advertising providers may retain information according to their own policies and our applicable account configurations.
+
+Your optional analytics and advertising choices remain in your browser until you change them, clear your browser data, or we update the consent-policy version and ask you to make a new choice.
+
+## 7. INTERNATIONAL TRANSFERS OF PERSONAL INFORMATION
+All personal information processed by us may be transferred, processed, and stored anywhere in the world, including, but not limited to, the United States or other countries, which may have data protection laws that are different from the laws where you live. Where required by applicable law, we use appropriate safeguards for international transfers of personal information.
+
+## 8. CHILDREN’S PERSONAL INFORMATION
 The Services are not directed to children under 18 (or other age as required by local law outside the United States), and we do not knowingly collect personal information from children.
 
-If you are a parent or guardian and believe your child has uploaded personal information to the Services in violation of applicable law, you may contact us as described in “[Contact Us](#9-contact-us)” below.
+If you are a parent or guardian and believe your child has uploaded personal information to the Services in violation of applicable law, you may contact us as described in “[Contact Us](#10-contact-us)” below.
 
-## 8. THIRD-PARTY WEBSITES/APPLICATIONS
+## 9. THIRD-PARTY WEBSITES/APPLICATIONS
 The Services may contain links to other websites/applications and other websites/applications may reference or link to our Services. These third-party services are not controlled by us. We encourage our users to read the privacy policies of each website and application with which they interact. We do not endorse, screen, or approve, and are not responsible for, the privacy practices or content of such other websites or applications. Providing personal information to third-party websites or applications is at your own risk. 
 
-## 9. CONTACT US 
+## 10. CONTACT US 
 Zoo is the controller of the personal information we process under this Privacy Notice. 
 
-If you have any questions about our privacy practices or this Privacy Notice, or to exercise your rights as detailed in this Privacy Notice, please reach our via our forum at: [community.zoo.dev](https://community.zoo.dev).
+If you have any questions about our privacy practices or this Privacy Notice, or to exercise your rights as detailed in this Privacy Notice, please email us at [support@zoo.dev](mailto:support@zoo.dev).

--- a/content/pages/privacy-policy.mdx
+++ b/content/pages/privacy-policy.mdx
@@ -97,7 +97,7 @@ We use personal information for various administrative purposes, such as:
 ### Marketing
 We may use personal information to tailor and provide you with marketing and other content. We may provide you with these materials as permitted by applicable law. 
 
-If you have any questions about our marketing practices, you may contact us at any time as set forth in “[Contact Us](#10-contact-us)” below. 
+If you have any questions about our marketing practices, you may contact us at any time as set forth in “[Contact Us](#10-contact-us)” below.
 
 ### With Your Consent or Direction 
 
@@ -110,11 +110,11 @@ We disclose personal information to third parties for a variety of business purp
 We may disclose any of the personal information we collect to the categories of third parties described below.
 
 - **Service Providers**. We may disclose personal information to third-party service providers that assist us with the provision of the Services. This may include, but is not limited to, service providers that provide us with hosting, customer service, analytics, marketing services, IT support, and related services. In addition, personal information and chat communications may be disclosed to service providers that help provide our chat features. Providers used for optional website analytics and advertising include:
-		- **Vercel Analytics and Speed Insights**. For more information, review the [Vercel Privacy Policy](https://vercel.com/legal/privacy-policy).
+		- **Vercel Analytics and Speed Insights**. For more information, review the [Vercel Privacy Notice](https://vercel.com/legal/privacy-notice).
 		- **Microsoft Clarity**. For more information, review the [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement).
 		- **Google Ads and Google Tag Manager**. For more information, review the [Google Privacy Policy](https://policies.google.com/privacy) and [Google Tag Manager Use Policy](https://marketingplatform.google.com/about/analytics/tag-manager/use-policy/).
 		- **LinkedIn**. For more information, review the [LinkedIn Privacy Policy](https://www.linkedin.com/legal/privacy-policy).
-		- **X (formerly known as Twitter)**. For more information, review the [X Privacy Policy](https://twitter.com/en/privacy).
+		- **X (formerly known as Twitter)**. For more information, review the [X Privacy Policy](https://x.com/en/privacy).
 		- **Reddit**. For more information, review the [Reddit Privacy Policy](https://www.reddit.com/policies/privacy-policy).
 - **Third-Party Services You Share or Interact With**. The Services may link to or allow you to interface, interact, share information with, direct us to share information with, access and/or use third-party websites, applications, services, products, and technology (each a “Third-Party Service”). Any personal information shared with a Third-Party Service will be subject to the Third- Party Service’s privacy policy. We are not responsible for the processing of personal information by Third-Party Services.
 - **Business Partners**. We may share your personal information with business partners to provide you with a product or service you have requested. We may also share your personal information with business partners with whom we jointly offer products or services.  Once your personal information is shared with our business partner, it will also be subject to our business partner’s privacy policy. We are not responsible for the processing of personal information by our business partners. 
@@ -171,7 +171,7 @@ If you are a parent or guardian and believe your child has uploaded personal inf
 ## 9. THIRD-PARTY WEBSITES/APPLICATIONS
 The Services may contain links to other websites/applications and other websites/applications may reference or link to our Services. These third-party services are not controlled by us. We encourage our users to read the privacy policies of each website and application with which they interact. We do not endorse, screen, or approve, and are not responsible for, the privacy practices or content of such other websites or applications. Providing personal information to third-party websites or applications is at your own risk. 
 
-## 10. CONTACT US 
+## 10. CONTACT US
 Zoo is the controller of the personal information we process under this Privacy Notice. 
 
 If you have any questions about our privacy practices or this Privacy Notice, or to exercise your rights as detailed in this Privacy Notice, please email us at [support@zoo.dev](mailto:support@zoo.dev).


### PR DESCRIPTION
### Summary
Updates Zoo’s Privacy Policy to reflect the new first-party consent controls introduced in the related website PR.

### Changes

- Documents the optional Analytics and Advertising consent categories.
- Lists the third-party providers associated with each category.
- Explains that optional technologies remain disabled unless enabled by the visitor.
- Documents how visitors can review, change, or withdraw consent through the website footer.
- Explains how consent choices, policy version, and update time are stored locally.
- Documents Global Privacy Control handling.
- Clarifies cookie removal limitations when consent is withdrawn.
- Adds a data-retention section.
- Updates section numbering and internal links.
- Removes outdated provider references.
- Updates provider privacy-policy links.
- Updates the Privacy Policy date to August 11, 2026.

### Related PR
Website consent implementation: KittyCAD/website#4360

### Testing

- Successfully generated all Contentlayer documents.
- Verified the MDX has no formatting or trailing-whitespace errors.
