### PR TITLE
Clarify Personal Cloud behavior

### DIFF
--- a/content/pages/docs/zoo-design-studio/features/data-management/cloud-sync.mdx
+++ b/content/pages/docs/zoo-design-studio/features/data-management/cloud-sync.mdx
@@ -17,11 +17,10 @@ When you change a Personal Cloud project, Zoo Design Studio saves the change to 
 first and syncs it to your Zoo account in the background. You can then open the latest synced
 version in the browser or on another device signed in to the same Zoo account.
 
-Zoo Design Studio adds Personal Cloud automatically for signed-in users with Cloud Sync. On desktop
-Home, it appears beside Directory libraries with a cloud icon and the address `zoo://personal`.
-Directory libraries have folder icons and show normal paths on your computer. In the browser,
-Personal Cloud is the default project library, so Home may open it directly instead of showing a
-separate library row.
+Zoo Design Studio adds Personal Cloud automatically for signed-in users. On desktop
+Home, it appears beside Directory libraries with a cloud icon.
+Directory libraries have folder icons and show normal paths on your computer, the default one is titled "Default Projects Directory". 
+In the browser, Personal Cloud is the only project library.
 
 <FramedImage
   src="/documentation-assets/docs/zoo-design-studio/features/data-management/project-libraries/project-libraries-home.webp"
@@ -47,8 +46,8 @@ Move a Directory project to Personal Cloud when you want to start syncing it.
 
 ### How Much Cloud Storage Do I Get?
 
-Zoo does not currently publish a Personal Cloud storage allowance, and Zoo Design Studio does not
-show used or remaining cloud storage. This does not mean that storage is unlimited.
+Storage is limited to what we consider fair use for Free users.
+Paid subscription tiers all get unlimited storage.
 
 ### Will Clearing My Browser Cache Delete My Cloud Projects?
 

--- a/content/pages/docs/zoo-design-studio/features/data-management/cloud-sync.mdx
+++ b/content/pages/docs/zoo-design-studio/features/data-management/cloud-sync.mdx
@@ -4,17 +4,31 @@ excerpt: Keep Personal Cloud projects up to date across your devices.
 sidebarPosition: 4
 ---
 
-Personal Cloud is Zoo Design Studio's cloud storage for projects. Cloud Sync keeps those projects up
-to date across your devices; it does not sync every project on your computer.
+Personal Cloud is the only project library that syncs with your Zoo account. Zoo Design Studio does
+not automatically upload every project on your computer.
 
-- A project in a **Directory** library stays in the folder you chose on that computer. Zoo Design
-  Studio does not upload it.
-- A project in **Personal Cloud** is stored in your Zoo account. On desktop, Zoo Design Studio also
-  keeps a working copy in a separate, managed folder while you edit.
+- **Personal Cloud projects sync.** They are stored in your Zoo account so you can open them in the
+  browser and on other devices. On desktop, Zoo Design Studio also keeps a working copy in a
+  separate, managed folder while you edit.
+- **Directory projects do not sync.** They stay in the folder you chose on that computer and are not
+  uploaded unless you move them to Personal Cloud.
 
 When you change a Personal Cloud project, Zoo Design Studio saves the change to the working copy
 first and syncs it to your Zoo account in the background. You can then open the latest synced
 version in the browser or on another device signed in to the same Zoo account.
+
+Zoo Design Studio adds Personal Cloud automatically for signed-in users with Cloud Sync. On desktop
+Home, it appears beside Directory libraries with a cloud icon and the address `zoo://personal`.
+Directory libraries have folder icons and show normal paths on your computer. In the browser,
+Personal Cloud is the default project library, so Home may open it directly instead of showing a
+separate library row.
+
+<FramedImage
+  src="/documentation-assets/docs/zoo-design-studio/features/data-management/project-libraries/project-libraries-home.webp"
+  alt="Home showing a Directory library with a folder icon and local path beside Personal Cloud with a cloud icon and zoo://personal address"
+  aspect="1000 / 650"
+  maxHeightPx={520}
+/>
 
 <FramedImage
   src="/documentation-assets/docs/zoo-design-studio/features/data-management/cloud-sync/cloud-sync-status.webp"
@@ -25,14 +39,34 @@ version in the browser or on another device signed in to the same Zoo account.
 
 ## Common Questions
 
+### How Do I Know Which Projects Are Saved to the Cloud?
+
+Check the library that contains the project on Home. Only projects in `Personal Cloud` are saved to
+your Zoo account. Projects in a Directory library are local-only, even while Cloud Sync is enabled.
+Move a Directory project to Personal Cloud when you want to start syncing it.
+
+### How Much Cloud Storage Do I Get?
+
+Zoo does not currently publish a Personal Cloud storage allowance, and Zoo Design Studio does not
+show used or remaining cloud storage. This does not mean that storage is unlimited.
+
+### Will Clearing My Browser Cache Delete My Cloud Projects?
+
+No. Clearing the browser's cached images and files does not delete projects from Personal Cloud.
+
+Clearing Zoo Design Studio's **site data or site storage** is different: it removes the working
+copies downloaded in that browser and any pending sync data stored there. Projects that reached
+`Cloud synced` remain in your Zoo account and download again when you open them. New projects or
+changes that had not reached `Cloud synced` can be lost, so wait for that status before clearing
+site data.
+
 ### Where Do My Files Live?
 
 Personal Cloud does not use the folders configured for your Directory libraries. On desktop, each
 cloud project gets a working copy in the managed Personal Cloud folder. You can see this folder's
 path under `Settings` > `User` > `App` > `Libraries` and reveal it in your file explorer.
 
-In the browser, the working copy lives in browser site storage rather than a normal folder. Clearing
-the site's data can remove that copy and any changes that have not reached `Cloud synced`.
+In the browser, the working copy lives in browser site storage rather than a normal folder.
 
 ### Can I Work Offline?
 

--- a/content/pages/docs/zoo-design-studio/features/data-management/import/step.mdx
+++ b/content/pages/docs/zoo-design-studio/features/data-management/import/step.mdx
@@ -33,9 +33,9 @@ workflow is to drag the `.step` or `.stp` file directly into the Project Files p
   project
 </div>
 
-You can also add the file outside Zoo Design Studio by placing it in the project folder next to
-`main.kcl`. After it is added, confirm that the STEP file appears in Project Files before
-referencing it from KCL.
+In the desktop app, you can also add the file outside Zoo Design Studio by placing it in the project
+folder next to `main.kcl`. After it is added, confirm that the STEP file appears in Project Files
+before referencing it from KCL.
 
 <FramedImage
   src="/documentation-assets/docs/zoo-design-studio/features/data-management/import/step/drag-and-drop-to-folder.gif"
@@ -101,9 +101,10 @@ same imported part.
 ## What STEP import supports
 
 STEP files can contain precise CAD boundary representation (BREP) geometry and product structure.
-Zoo Design Studio imports 3D geometry from `.step` and `.stp` files in the native desktop app. It
-does not support importing 2D drawings from STEP files. Foreign file imports currently work in the
-desktop app, not in the browser.
+Zoo Design Studio imports 3D geometry from `.step` and `.stp` files in both the desktop app and the
+browser. It does not support importing 2D drawings from STEP files. In the browser, drag the file
+into Project Files; the `Add file to project` Local Drive picker is available only in the desktop
+app.
 
 Imported STEP geometry:
 

--- a/content/pages/docs/zoo-design-studio/features/data-management/project-libraries.mdx
+++ b/content/pages/docs/zoo-design-studio/features/data-management/project-libraries.mdx
@@ -17,9 +17,16 @@ On desktop, there are two choices:
 These are separate locations. Adding a Directory library does not sync its projects. To start
 syncing a Directory project, move it to Personal Cloud.
 
+**Only projects in Personal Cloud sync to your Zoo account. Directory projects remain local-only.**
+
+Zoo Design Studio adds Personal Cloud automatically for signed-in users with Cloud Sync; you do not
+need to create it yourself. On desktop Home, its cloud icon and `zoo://personal` address distinguish
+it from Directory libraries, which have folder icons and normal paths on your computer. In the
+browser, Personal Cloud is the default project library and may open directly.
+
 <FramedImage
   src="/documentation-assets/docs/zoo-design-studio/features/data-management/project-libraries/project-libraries-home.webp"
-  alt="Project Libraries overview showing projects grouped under Workshop Projects and Personal Cloud"
+  alt="Home showing a Directory library with a folder icon and local path beside Personal Cloud with a cloud icon and zoo://personal address"
   aspect="1000 / 650"
   maxHeightPx={520}
 />

--- a/content/pages/docs/zoo-design-studio/features/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/index.mdx
@@ -61,8 +61,8 @@ channels for Design Studio users, including community and direct support paths.
 ### System Requirements
 
 [System Requirements](/docs/zoo-design-studio/features/system-requirements) covers supported
-platforms, including Windows, macOS, Linux, and the browser version, along with current browser
-limitations.
+platforms, including Windows, macOS, Linux, and the browser version, along with current platform
+differences.
 
 ### Workspace
 

--- a/content/pages/docs/zoo-design-studio/features/system-requirements/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/system-requirements/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: System Requirements
-excerpt: Supported platforms, Zoo Design Studio Stream behavior, and browser-version limitations in Zoo Design Studio.
+excerpt: Supported platforms and Zoo Design Studio Stream behavior in Zoo Design Studio.
 sidebarPosition: 9
 ---
 
 Zoo Design Studio is available as a native desktop application on Windows, macOS, and Linux. A web
 version is also available for browser-based use.
 
-The desktop applications are the full-featured path. The web version is useful for browser-based
-workflows and quick access.
+Both versions provide the core modeling workspace. Some workflows differ where the desktop app can
+access operating-system folders and applications.
 
 ## Supported Platforms
 
@@ -24,8 +24,10 @@ interactive CAD engine session on our cloud compute infrastructure and streams t
 back to your computer. This means Zoo Design Studio is not limited by the CAD hardware inside your
 local machine, though a stable network connection is still important for responsive modeling.
 
-## Web Version Caveats
+## Platform Differences
 
-- Multiple files in one workspace are supported.
-- Project files are stored in browser-managed storage rather than a normal folder on disk.
-- Full desktop-style multi-project workflows are not currently supported in the web version.
+- Both versions support multiple project files and projects.
+- On desktop, Directory libraries can point to normal folders on disk. The web version uses Personal
+  Cloud and keeps working copies in browser-managed storage.
+- Operating-system integrations such as `Reveal in file explorer`, `New Window`, and
+  `Export to Slicer` are desktop workflows.

--- a/content/pages/docs/zoo-design-studio/features/system-requirements/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/system-requirements/index.mdx
@@ -27,7 +27,7 @@ local machine, though a stable network connection is still important for respons
 ## Platform Differences
 
 - Both versions support multiple project files and projects.
-- On desktop, Directory libraries can point to normal folders on disk. The web version uses Personal
-  Cloud and keeps working copies in browser-managed storage.
+- On desktop, Directory libraries can point to normal folders on disk. The web version only works with projects from Personal
+  Cloud.
 - Operating-system integrations such as `Reveal in file explorer`, `New Window`, and
   `Export to Slicer` are desktop workflows.

--- a/content/pages/docs/zoo-design-studio/features/system-requirements/zoo-stream/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/system-requirements/zoo-stream/index.mdx
@@ -115,10 +115,10 @@ centrally.
 Zoo Design Studio Stream is about execution and visualization. It does not change the app's
 source-file storage model.
 
-In the desktop app, CAD source files are stored on your device. In the browser version, project files
-use browser-managed storage. The cloud session receives the model data needed to run the engine and
-produce the interactive stream, but the streaming architecture is not a permanent storage migration
-for your project files.
+Directory-library projects remain in folders on your desktop computer. Personal Cloud projects
+remain stored in your Zoo account, with a working copy in a managed desktop folder or
+browser-managed storage. The cloud session receives the model data needed to run the engine and
+produce the interactive stream, but it does not decide where your project is stored.
 
 That split is the point: keep the control and portability of the app's project storage model while
 using remote compute for the expensive CAD work.

--- a/content/pages/docs/zoo-design-studio/features/system-requirements/zoo-stream/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/system-requirements/zoo-stream/index.mdx
@@ -117,7 +117,7 @@ source-file storage model.
 
 Directory-library projects remain in folders on your desktop computer. Personal Cloud projects
 remain stored in your Zoo account, with a working copy in a managed desktop folder or
-browser-managed storage. The cloud session receives the model data needed to run the engine and
+browser-managed cache. The cloud session receives the model data needed to run the engine and
 produce the interactive stream, but it does not decide where your project is stored.
 
 That split is the point: keep the control and portability of the app's project storage model while

--- a/content/pages/docs/zoo-design-studio/features/workspace/file-explorer.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/file-explorer.mdx
@@ -20,7 +20,7 @@ The File Explorer shows the files and folders inside the current project.
 - Rename files and folders.
 - Copy, paste, and drag entries within the project.
 - Archive entries you no longer need.
-- Import supported external files by drag and drop on desktop.
+- Import supported external files by dragging them into Project Files on desktop or in the browser.
 - Open `.kcl` files directly for editing.
 - Reveal the project, or an individual file or folder, in the system file manager on desktop.
 
@@ -36,10 +36,12 @@ select `Reveal in file explorer`.
 This option is available only in the desktop app. It is hidden in the browser because browser
 projects do not expose the same local filesystem paths.
 
+In the browser, drag files from your computer directly into Project Files. The `Add file to project`
+Local Drive picker is available only in the desktop app.
+
 ## What You Cannot Do
 
 - Open non-KCL files as editable KCL documents.
-- Expect desktop filesystem behavior in browser-only contexts.
 - Keep sketch mode active while switching files when the app needs to cancel it first.
 
 ## Key Differences in This Area

--- a/content/pages/docs/zoo-design-studio/features/workspace/file-explorer.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/file-explorer.mdx
@@ -20,7 +20,7 @@ The File Explorer shows the files and folders inside the current project.
 - Rename files and folders.
 - Copy, paste, and drag entries within the project.
 - Archive entries you no longer need.
-- Import supported external files by dragging them into Project Files on desktop or in the browser.
+- Import supported external files by dragging them into Project Files
 - Open `.kcl` files directly for editing.
 - Reveal the project, or an individual file or folder, in the system file manager on desktop.
 
@@ -35,9 +35,6 @@ select `Reveal in file explorer`.
 
 This option is available only in the desktop app. It is hidden in the browser because browser
 projects do not expose the same local filesystem paths.
-
-In the browser, drag files from your computer directly into Project Files. The `Add file to project`
-Local Drive picker is available only in the desktop app.
 
 ## What You Cannot Do
 

--- a/content/pages/docs/zoo-design-studio/features/workspace/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/index.mdx
@@ -15,15 +15,11 @@ across part modeling, assemblies, and direct KCL editing.
 - Use the left and right pane zones for different tools and editors.
 - Use pane shortcuts such as `Shift+T` for Feature Tree and `Shift+C` for Code Editor.
 
-## What You Cannot Do
-
-- Expect every desktop pane behavior in browser mode.
-- Use desktop-only file workflows or make-related actions in the browser build.
-
 ## Key Differences in This Area
 
 - The code editor and AI assistant are first-class workspace panes, not secondary add-ons.
-- Some pane behavior is platform-dependent, especially around files and local project workflows.
+- Browser projects use browser-managed storage. Operating-system integrations such as revealing
+  files, opening desktop windows, and make-related actions are desktop workflows.
 
 Start with [Project Browser](/docs/zoo-design-studio/features/workspace/project-browser) for opening and
 creating work. Use [New Window](/docs/zoo-design-studio/features/workspace/new-window) when you need

--- a/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/app/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/app/index.mdx
@@ -27,7 +27,7 @@ folder.
 With Cloud Sync, the `Personal Cloud` library appears as a Cloud library. Its settings
 row shows the resolved local storage path for the cloud working copy.
 
-On web, Project Libraries are limited to Personal Cloud. Browser storage is not a
+In the browser, projects use Personal Cloud. Browser storage is not a
 normal local folder, so Zoo Design Studio treats browser projects as cloud-backed projects rather than
 showing local-only browser libraries.
 

--- a/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/app/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/app/index.mdx
@@ -28,8 +28,8 @@ With Cloud Sync, the `Personal Cloud` library appears as a Cloud library. Its se
 row shows the resolved local storage path for the cloud working copy.
 
 In the browser, projects use Personal Cloud. Browser storage is not a
-normal local folder, so Zoo Design Studio treats browser projects as cloud-backed projects rather than
-showing local-only browser libraries.
+normal local folder, so Zoo Design Studio treats all projects as cloud-backed projects rather than
+showing local-only browser libraries, which would not follow the user's account.
 
 For the full storage model, see
 [Project Libraries](/docs/zoo-design-studio/features/data-management/project-libraries) and

--- a/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/resets/index.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/settings/user-settings/resets/index.mdx
@@ -16,10 +16,9 @@ Replay the onboarding process.
 
 Restore settings to their default values.
 
-Your settings are saved in a file in the app data folder for your operating system.
-
-On desktop, the reset area also includes `Show in folder`. The reset action for this tab is `Reset
-user-level settings`.
+On desktop, your settings are saved in a file in the app data folder for your operating system, and
+the reset area also includes `Show in folder`. The reset action for this tab is `Reset user-level
+settings`.
 
 ## Layout
 

--- a/content/pages/docs/zoo-design-studio/features/workspace/top-bar.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/top-bar.mdx
@@ -14,7 +14,7 @@ publishing, and account actions.
 
 It contains:
 
-- The Zoo logo, which returns to home or the project list on desktop
+- The Zoo logo, which returns to Home on desktop and in the browser with Personal Cloud
 - A project dropdown menu when the menu is enabled
 - The current project and file breadcrumb in the dropdown trigger
 - The project name as static text when the dropdown is not enabled
@@ -26,7 +26,7 @@ The project dropdown can include:
 - `Add file to project`, with its keyboard shortcut
 - `Export current part`, with its keyboard shortcut
 - `Make current part`, on desktop
-- `Go to Home`, on desktop
+- `Go to Home`, on desktop and in the browser with Personal Cloud
 - `New Window`, on desktop when you want a separate workspace
 
 `Export current part` and `Make current part` can show `Awaiting engine connection` when the
@@ -100,8 +100,8 @@ The Top Bar typically appears in this order:
 
 - The exact arrangement changes slightly with screen size and platform
 - The Publish button is hidden in smaller layouts
-- Desktop-only actions such as `Make current part`, `Go to Home`, `New Window`, and `Check for updates` are not
-  shown in the web version
+- Desktop-only actions such as `Make current part`, `New Window`, and `Check for updates` are not shown in
+  the web version
 
 ## What This Page Does Not Cover
 

--- a/content/pages/docs/zoo-design-studio/features/workspace/top-bar.mdx
+++ b/content/pages/docs/zoo-design-studio/features/workspace/top-bar.mdx
@@ -14,7 +14,7 @@ publishing, and account actions.
 
 It contains:
 
-- The Zoo logo, which returns to Home on desktop and in the browser with Personal Cloud
+- The Zoo logo, which returns to Home
 - A project dropdown menu when the menu is enabled
 - The current project and file breadcrumb in the dropdown trigger
 - The project name as static text when the dropdown is not enabled
@@ -26,7 +26,7 @@ The project dropdown can include:
 - `Add file to project`, with its keyboard shortcut
 - `Export current part`, with its keyboard shortcut
 - `Make current part`, on desktop
-- `Go to Home`, on desktop and in the browser with Personal Cloud
+- `Go to Home`, on desktop and in the browser
 - `New Window`, on desktop when you want a separate workspace
 
 `Export current part` and `Make current part` can show `Awaiting engine connection` when the

--- a/content/pages/docs/zoo-design-studio/index.mdx
+++ b/content/pages/docs/zoo-design-studio/index.mdx
@@ -26,7 +26,7 @@ first-time users. It covers the following topics:
 
 - [Getting started](/docs/zoo-design-studio/getting-started#getting-started)
 - [Creating a new project](/docs/zoo-design-studio/getting-started#creating-a-new-project)
-- [Desktop vs browser version](/docs/zoo-design-studio/getting-started#desktop-vs-browser-version)
+- [Desktop vs browser version](/docs/zoo-design-studio/features/system-requirements)
 - [Zookeeper basics](/docs/zoo-design-studio/getting-started#zookeeper-basics)
 - [Sketch basics](/docs/zoo-design-studio/getting-started#sketch-basics)
 - [KCL basics](/docs/zoo-design-studio/getting-started#kcl-basics)

--- a/content/pages/docs/zoo-design-studio/index.mdx
+++ b/content/pages/docs/zoo-design-studio/index.mdx
@@ -26,7 +26,6 @@ first-time users. It covers the following topics:
 
 - [Getting started](/docs/zoo-design-studio/getting-started#getting-started)
 - [Creating a new project](/docs/zoo-design-studio/getting-started#creating-a-new-project)
-- [Desktop vs browser version](/docs/zoo-design-studio/features/system-requirements)
 - [Zookeeper basics](/docs/zoo-design-studio/getting-started#zookeeper-basics)
 - [Sketch basics](/docs/zoo-design-studio/getting-started#sketch-basics)
 - [KCL basics](/docs/zoo-design-studio/getting-started#kcl-basics)


### PR DESCRIPTION
Stacked on #981 ✅ 

Clarifies which projects sync, how Personal Cloud appears on Home, the current lack of a published storage allowance or usage meter, and what browser cache versus site-data clearing removes.